### PR TITLE
Fixed small Bug in summarize script

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -3,6 +3,9 @@
 * Add output mode: result for each domain in human readable form.
   => Activate automatically when taking domain names on CLI.
 
+* i18n csv-result-to-summary.pl for other languages then german ... ;-)
+
+
 * store if web check was successful with www. or without; => use this in CipherStrengts 
 
 * New Subtests:


### PR DESCRIPTION
When there was 0 HTTPS domains in the result, the summarize script
failed with division by zero.
Now it gives ---%
